### PR TITLE
Updates _config/cms.yml for incorrect path

### DIFF
--- a/_config/cms.yml
+++ b/_config/cms.yml
@@ -3,8 +3,8 @@ Name: LinkItemField CMS config
 ---
 SilverStripe\Admin\LeftAndMain:
   extra_requirements_javascript:
-    - resources/cyber-duck/silverstripe-linkitemfield/assets/js/linkitemfield.js
+    - vendor/cyber-duck/silverstripe-linkitemfield/assets/js/linkitemfield.js
   extra_requirements_css:
-    - resources/cyber-duck/silverstripe-linkitemfield/assets/css/linkitemfield.css
+    - vendor/cyber-duck/silverstripe-linkitemfield/assets/css/linkitemfield.css
   admin_themes:
    - 'silverstripe-linkitemfield'


### PR DESCRIPTION
Fixes issue #1: File resources/cyber-duck/silverstripe-linkitemfield/assets/js/linkitemfield.js does not exist

Changed path from resources to vendor for JS and CSS file.