### PR TITLE
Field labels

### DIFF
--- a/src/Forms/LinkItemField.php
+++ b/src/Forms/LinkItemField.php
@@ -245,20 +245,6 @@ class LinkItemField extends FormField
     }
 
     /**
-     * Returns a human friendly label to use in the template.
-     *
-     * @return string
-     **/
-    public function getLinkLabel()
-    {
-        if ($this->Value() > 0) {
-            $link = DataObject::get_by_id(LinkItem::class, $this->Value());
-            return "{$link->Title} ({$link->Link()})";
-        }
-        return '';
-    }
-
-    /**
      * Show the label instead of the ID value when the field is readonly.
      *
      * @return string

--- a/src/Forms/LinkItemField.php
+++ b/src/Forms/LinkItemField.php
@@ -229,4 +229,48 @@ class LinkItemField extends FormField
         }
         return true;
     }
+
+    /**
+     * Returns a human friendly label to use in the template.
+     *
+     * @return string
+     **/
+    public function getLinkLabel()
+    {
+        if ($this->Value() > 0) {
+            $link = DataObject::get_by_id(LinkItem::class, $this->Value());
+            return "{$link->Title} ({$link->Link()})";
+        }
+        return '';
+    }
+
+    /**
+     * Returns a human friendly label to use in the template.
+     *
+     * @return string
+     **/
+    public function getLinkLabel()
+    {
+        if ($this->Value() > 0) {
+            $link = DataObject::get_by_id(LinkItem::class, $this->Value());
+            return "{$link->Title} ({$link->Link()})";
+        }
+        return '';
+    }
+
+    /**
+     * Show the label instead of the ID value when the field is readonly.
+     *
+     * @return string
+     **/
+    public function performReadonlyTransformation()
+    {
+        $readonlyClassName = static::class . '_Readonly';
+
+        $clone = $this->castedCopy(ReadonlyField::class);
+        $clone->setValue($this->getLinkLabel());
+        $clone->setReadonly(true);
+
+        return $clone;
+    }
 }

--- a/src/Forms/LinkItemField.php
+++ b/src/Forms/LinkItemField.php
@@ -15,6 +15,7 @@ use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HiddenField;
+use SilverStripe\Forms\ReadonlyField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\ORM\DataObject;
@@ -251,8 +252,6 @@ class LinkItemField extends FormField
      **/
     public function performReadonlyTransformation()
     {
-        $readonlyClassName = static::class . '_Readonly';
-
         $clone = $this->castedCopy(ReadonlyField::class);
         $clone->setValue($this->getLinkLabel());
         $clone->setReadonly(true);


### PR DESCRIPTION
Currently the field shows the link path when is in standard mode and the numeric ID when it's in readonly mode (e.g. history). This pull request adds the title to the link value in standard mode (following this format: `title (linkpath)`) and prints the same value in the readonly field.