### PR TITLE
Fix requirement paths.

### DIFF
--- a/_config/cms.yml
+++ b/_config/cms.yml
@@ -3,8 +3,8 @@ Name: LinkItemField CMS config
 ---
 SilverStripe\Admin\LeftAndMain:
   extra_requirements_javascript:
-    - resources/vendor/cyber-duck/silverstripe-linkitemfield/assets/js/linkitemfield.js
+    - 'cyber-duck/silverstripe-linkitemfield:assets/js/linkitemfield.js'
   extra_requirements_css:
-    - resources/vendor/cyber-duck/silverstripe-linkitemfield/assets/css/linkitemfield.css
+    - 'cyber-duck/silverstripe-linkitemfield:assets/css/linkitemfield.css'
   admin_themes:
    - 'silverstripe-linkitemfield'


### PR DESCRIPTION
I took the hint from a package that always works properly and has the correct include path for admin assets: [dnadesign/silverstripe-elemental](https://github.com/dnadesign/silverstripe-elemental/blob/master/_config/config.yml#L7)

Another project with the correct path (they don't define it in yml, instead in the main class for the package) is [ryanpotter/silverstripe-color-field](https://github.com/Rhym/silverstripe-color-field/blob/master/src/Forms/ColorField.php#L42)

You have another similar PR open, but you should close that and accept this one.  This is the actual correct path.  This accounts for projects where the `resources-dir` has been changed via the composer file.  The files will always load properly using this configuration.

To be clear, the package is broken for projects where the `resources-dir` has changed.  The CMS will not load, and the error message is:

```
[User Notice] File resources/vendor/cyber-duck/silverstripe-linkitemfield/assets/js/linkitemfield.js does not exist
GET /admin/pages/edit/show/6
Line 90 in /var/www/html/vendor/silverstripe/framework/src/Control/SimpleResourceURLGenerator.php

Trace
trigger_error(File resources/vendor/cyber-duck/silverstripe-linkitemfield/assets/js/linkitemfield.js does not exist, 1024) 
SimpleResourceURLGenerator.php:90
SilverStripe\Control\SimpleResourceURLGenerator->urlForResource(resources/vendor/cyber-duck/silverstripe-linkitemfield/assets/js/linkitemfield.js) 
Requirements_Backend.php:1055
SilverStripe\View\Requirements_Backend->pathForFile(resources/vendor/cyber-duck/silverstripe-linkitemfield/assets/js/linkitemfield.js) 
Requirements_Backend.php:809
```

In my project, `resources-dir` is set to `_resources`, and thus will not load at the configured path.  If the path is updated as per this PR, it will load at the correct path of `/_resources/vendor/cyber-duck/silverstripe-linkitemfield/assets/js/linkitemfield.[js/css]`

