### PR TITLE
Upgrade deprecated code.

### DIFF
--- a/src/Forms/LinkItemField.php
+++ b/src/Forms/LinkItemField.php
@@ -210,7 +210,7 @@ class LinkItemField extends FormField
         $obj->write();
 
         Controller::curr()->getResponse()->addHeader('Content-Type', 'application/json');
-        return Convert::raw2json([
+        return json_encode([
             'success' => true,
             'name'    => $this->getRequest()->postVar('Relation'),
             'id'      => $obj->ID,


### PR DESCRIPTION
`Convert::raw2json` is deprecated; use `json_encode`.  Under the covers `Convert::raw2json()` is just using `json_encode` with the same arguments.

This is the only deprecated function in this package that SilverStripe 4.5 warned me about, so I think you might be set now.