### PR TITLE
Removes duplicate symbol definition

### DIFF
--- a/src/Model/LinkItem.php
+++ b/src/Model/LinkItem.php
@@ -2,7 +2,6 @@
 
 namespace CyberDuck\LinkItemField\Model;
 
-use CyberDuck\LinkItemField\Model\LinkItem;
 use SilverStripe\AssetAdmin\Forms\UploadField;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Assets\File;


### PR DESCRIPTION
This class does not need to `use` itself.

This doesn't seem to break anything but it does for some reason prevent VSCode/Intelephense from autocompleting and adding this class to other classes. Removing this line makes autocompletion work.