### PR TITLE
Remove mandatory "+" on tel: links

### DIFF
--- a/src/Forms/LinkItemField.php
+++ b/src/Forms/LinkItemField.php
@@ -160,7 +160,7 @@ class LinkItemField extends FormField
                     ->addExtraClass('link-hidden link-external'),
                 EmailField::create('Email', 'Email (without mailto:)')
                     ->addExtraClass('link-hidden link-email'),
-                TextField::create('Telephone', 'Telephone (without +)')
+                TextField::create('Telephone', 'Telephone')
                     ->addExtraClass('link-hidden link-telephone'),
                 UploadField::create('File', 'File')
                     ->addExtraClass('link-hidden link-file')

--- a/src/Model/LinkItem.php
+++ b/src/Model/LinkItem.php
@@ -134,7 +134,7 @@ class LinkItem extends DataObject
                 ->hideUnless('LinkType')->isEqualTo('external')->end(),
             EmailField::create('Email', 'Email (without mailto:)')
                 ->hideUnless('LinkType')->isEqualTo('email')->end(),
-            TextField::create('Telephone', 'Telephone (without +)')
+            TextField::create('Telephone', 'Telephone')
                 ->hideUnless('LinkType')->isEqualTo('telephone')->end(),
             UploadField::create('File', 'File')
                 ->setFolderName('Uploads')
@@ -189,7 +189,7 @@ class LinkItem extends DataObject
                 $link = 'mailto:'.$this->Email;
             break;
             case 'telephone':
-                $link = 'tel:+'.$this->Telephone;
+                $link = 'tel:'.$this->Telephone;
             break;
             case 'file':
                 $link = $this->File()->URL;


### PR DESCRIPTION
Removes the hard-coded "+" before tel: links, as these are not needed or valid in some instances.