### PR TITLE
Fixed uncalled updateCMSFields hook in getCMSFields.

### DIFF
--- a/src/Model/LinkItem.php
+++ b/src/Model/LinkItem.php
@@ -120,7 +120,7 @@ class LinkItem extends DataObject
      **/
     public function getCMSFields()
     {
-        return FieldList::create([
+        $fields = FieldList::create([
             TextField::create('Title'),
             DropdownField::create('LinkType', 'Link Type')
                 ->addExtraClass('link-item-switcher')
@@ -148,6 +148,8 @@ class LinkItem extends DataObject
                 ->setEmptyString('- select type -')
                 ->setSource(singleton(LinkItem::class)->getTargets()),
         ]);
+        $this->extend('updateCMSFields', $fields);
+        return $fields;
     }
     
     /**


### PR DESCRIPTION
Include 'updateCMSFields' Hook in  the `getCMSFields` method. This is quite helpful when extending the Model using DataExtension.